### PR TITLE
parse aws region

### DIFF
--- a/.github/workflows/deploy_backend.yml
+++ b/.github/workflows/deploy_backend.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   deploy:
     name: Deploy to EC2
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     env:
       AWS_INSTANCE_SG_ID: ${{ secrets.AWS_INSTANCE_SG_ID }}
@@ -24,6 +27,8 @@ jobs:
       with:
         role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_ROLE_NAME }}
         aws-region: ${{ env.AWS_REGION }}
+        role-session-name: GHActionsBackendDeployment
+        web-identity-token-file: ${{ env.ACTIONS_ID_TOKEN_REQUEST_TOKEN }}
 
     - name: Get runner public IP address
       id: ip

--- a/.github/workflows/deploy_backend.yml
+++ b/.github/workflows/deploy_backend.yml
@@ -22,8 +22,8 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v2
       with:
-        role-to-assume: arn:aws:iam::$AWS_ACCOUNT_ID:role/$AWS_ROLE_NAME
-        aws-region: $AWS_REGION
+        role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_ROLE_NAME }}
+        aws-region: ${{ env.AWS_REGION }}
 
     - name: Get runner public IP address
       id: ip

--- a/.github/workflows/deploy_backend.yml
+++ b/.github/workflows/deploy_backend.yml
@@ -51,7 +51,7 @@ jobs:
         key: ${{ secrets.EC2_SSH_KEY }}
         script: |
           cd ~/yt_translator
-          app/post_update.sh
+          sudo app/post_update.sh
 
     - name: Revoke GitHub Actions runner IP address
       run: |


### PR DESCRIPTION
parse aws region as `aws-actions/configure-aws-credentials@v2` action doesn’t resolve env variables directly, so it was treating $AWS_REGION as a literal string